### PR TITLE
feat: LSTM모델 추가

### DIFF
--- a/Code/model/lstm.py
+++ b/Code/model/lstm.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    def __init__(self, input_size, hidden_size, output_size, num_layers):
+        super(Model, self).__init__()
+        # input_size: features 컬럼 수만큼 입력
+        # output_size : 결과값 Colum 수
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.input_size = input_size
+        self.output_size = output_size
+        self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
+        self.fc = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x) -> torch.tensor:
+        h_0 = torch.zeros(self.num_layers, x.size(0), self.hidden_size)
+        c_0 = torch.zeros(self.num_layers, x.size(0), self.hidden_size)
+
+        out, _ = self.lstm(x, (h_0, c_0))
+        out = self.fc(out[:, -1, :])  # 마지막 시점의 출력을 사용
+        return out
+
+    def predict(self, x) -> torch.tensor:
+        return self.forward(x)
+
+    def fit(self, x_train: torch.tensor, y_train: torch.tensor):
+        from torch.utils.data import DataLoader, TensorDataset
+
+        # DataLoader 준비
+        train_dataset = TensorDataset(x_train.unsqueeze(1), y_train)
+        train_loader = DataLoader(dataset=train_dataset, batch_size=2, shuffle=False)
+
+        # 모델 초기화
+
+        model = Model(
+            self.input_size, self.hidden_size, self.output_size, self.num_layers
+        )
+        # 손실 함수 및 옵티마이저 설정
+        criterion = nn.MSELoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+
+        # 학습
+        num_epochs = 100
+        for epoch in range(num_epochs):
+            for X_batch, y_batch in train_loader:
+                outputs = model(X_batch)
+                loss = criterion(outputs, y_batch.unsqueeze(1))
+
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+            if (epoch + 1) % 10 == 0:
+                print(f"Epoch [{epoch + 1}/{num_epochs}], Loss: {loss.item():.4f}")


### PR DESCRIPTION
LSTM 기본 모델 추가 및 사용 방법 제시
-----

해당 방법은 Dacon의 비트코인 예측 모델 대회에서 사용된 모델의 아이디어 기반으로 작성됨.
하지만 해당 방법으로 작성하였을때, `-`로 **수렴하는 문제**가 있었음.
이에 별도의 Feature 엔지니어링(#16 )을 통해 테스트 하였으나, 적절히 수렴되지 않으므로
다른 Feature 엔지니어링 방법이 필요할 것으로 보임. 

----

시계열 데이터 예측을 위한 모델이며, 사용방법은 아래와 같음

아래와 같은 예제로 사용 가능

```python
select_col = ["target_ratio", "sell_buy_01", "sell_buy_r_v_diff", "volume_diff", "liquidation_diff"]

features = train_df[select_col].drop(columns=["target_ratio"]).values
target = train_df["target_ratio"].values

# 데이터 정규화 (Min-Max 스케일링)
scaler = MinMaxScaler()
features_scaled = scaler.fit_transform(features)

test = pre_process(df.loc[df["_type"] == "test"])[select_col]
# PyTorch Tensor로 변환
X_train_tensors = torch.tensor(features_scaled, dtype=torch.float32)
y_train_tensors = torch.tensor(target, dtype=torch.float32)
X_test_tensors = torch.tensor(scaler.fit_transform(test.drop(columns=["target_ratio"])), dtype=torch.float32)

device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
cuda = True if torch.cuda.is_available() else False

torch.manual_seed(42)
if torch.cuda.is_available():
    torch.cuda.manual_seed_all(42)

# 모델 초기화
input_size = features.shape[1]  # features 컬럼 수만큼 입력
hidden_size = 50
output_size = 1
num_layers = 4
model = lstm(input_size, hidden_size, output_size, num_layers)
model.fit(X_train_tensors, y_train_tensors)
pred = model.predict(X_test_tensors)
```
